### PR TITLE
Add possibility to customize special button behaviour

### DIFF
--- a/app/src/main/java/com/konaire/sample/MainActivity.kt
+++ b/app/src/main/java/com/konaire/sample/MainActivity.kt
@@ -2,6 +2,8 @@ package com.konaire.sample
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import android.widget.Toast
+import kotlinx.android.synthetic.main.activity_main.*
 
 /**
  * Created by Evgeny Eliseyev on 10/02/2018.
@@ -11,5 +13,16 @@ class MainActivity: AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // Add decimal separator
+        //keyboard.keySpecialText = "."
+
+        /*
+            // Example code to customize special button behaviour
+            keyboard.keySpecialText = "TOAST"
+            keyboard.onKeySpecialClick {
+                Toast.makeText(this, "Special key pressed!", Toast.LENGTH_SHORT).show()
+            }
+        */
     }
 }

--- a/app/src/main/java/com/konaire/sample/MainActivity.kt
+++ b/app/src/main/java/com/konaire/sample/MainActivity.kt
@@ -2,8 +2,6 @@ package com.konaire.sample
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import android.widget.Toast
-import kotlinx.android.synthetic.main.activity_main.*
 
 /**
  * Created by Evgeny Eliseyev on 10/02/2018.
@@ -13,16 +11,5 @@ class MainActivity: AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-
-        // Add decimal separator
-        //keyboard.keySpecialText = "."
-
-        /*
-            // Example code to customize special button behaviour
-            keyboard.keySpecialText = "TOAST"
-            keyboard.onKeySpecialClick {
-                Toast.makeText(this, "Special key pressed!", Toast.LENGTH_SHORT).show()
-            }
-        */
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        gradleVersion = '3.2.1'
+        gradleVersion = '3.3.0'
         kotlinVersion = '1.3.11'
         supportVersion = '27.1.1'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Dec 18 14:55:51 CET 2018
+#Wed Jan 23 10:12:10 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/numeric-keyboard/src/main/java/com/konaire/numerickeyboard/NumericKeyboard.kt
+++ b/numeric-keyboard/src/main/java/com/konaire/numerickeyboard/NumericKeyboard.kt
@@ -96,12 +96,6 @@ class NumericKeyboard: FrameLayout {
             }
         }
 
-    fun onKeySpecialClick(function: (() -> Unit)) {
-        keySpecialListener = OnClickListener {
-            function.invoke()
-        }
-    }
-
     private fun initAttributes(context: Context, attrs: AttributeSet, defStyleAttr: Int) {
         val attributes = context.theme.obtainStyledAttributes(attrs, R.styleable.NumericKeyboard, defStyleAttr, 0)
         val defaultKeyTextSize = context.resources.getDimensionPixelSize(R.dimen.keyboard_text_size)
@@ -201,13 +195,7 @@ class NumericKeyboard: FrameLayout {
         }
 
         keySpecial.text = keySpecialText
-        if (keySpecialText != "") {
-            keySpecial.isEnabled = true
-        }
-        if (keySpecialListener != null) {
-            keySpecial.setOnClickListener(keySpecialListener)
-        } else {
-            keySpecial.setOnClickListener(listener)
-        }
+        keySpecial.isEnabled = keySpecialText.isNotEmpty()
+        keySpecial.setOnClickListener(keySpecialListener ?: listener)
     }
 }

--- a/numeric-keyboard/src/main/java/com/konaire/numerickeyboard/NumericKeyboard.kt
+++ b/numeric-keyboard/src/main/java/com/konaire/numerickeyboard/NumericKeyboard.kt
@@ -80,6 +80,28 @@ class NumericKeyboard: FrameLayout {
             }
         }
 
+    var keySpecialText: String = ""
+        set(value) {
+            field = value
+            if (childCount > 0) {
+                updateView(getChildAt(0))
+            }
+        }
+
+    var keySpecialListener: OnClickListener? = null
+        set(value) {
+            field = value
+            if (childCount > 0) {
+                updateView(getChildAt(0))
+            }
+        }
+
+    fun onKeySpecialClick(function: (() -> Unit)) {
+        keySpecialListener = OnClickListener {
+            function.invoke()
+        }
+    }
+
     private fun initAttributes(context: Context, attrs: AttributeSet, defStyleAttr: Int) {
         val attributes = context.theme.obtainStyledAttributes(attrs, R.styleable.NumericKeyboard, defStyleAttr, 0)
         val defaultKeyTextSize = context.resources.getDimensionPixelSize(R.dimen.keyboard_text_size)
@@ -123,6 +145,7 @@ class NumericKeyboard: FrameLayout {
         val key9 = layout.findViewById<TextView>(R.id.key9)
         val key0 = layout.findViewById<TextView>(R.id.key0)
         val keyRemove = layout.findViewById<TextView>(R.id.keyRemove)
+        val keySpecial = layout.findViewById<TextView>(R.id.keySpecial)
         val listener = KeyClickListener(fieldMaxLength, field)
 
         row1.layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, keyHeight)
@@ -141,6 +164,7 @@ class NumericKeyboard: FrameLayout {
         key9.setTextColor(keyTextColor)
         key0.setTextColor(keyTextColor)
         keyRemove.setTextColor(keyTextColor)
+        keySpecial.setTextColor(keyTextColor)
 
         key1.setTextSize(TypedValue.COMPLEX_UNIT_PX, keyTextSize)
         key2.setTextSize(TypedValue.COMPLEX_UNIT_PX, keyTextSize)
@@ -153,6 +177,7 @@ class NumericKeyboard: FrameLayout {
         key9.setTextSize(TypedValue.COMPLEX_UNIT_PX, keyTextSize)
         key0.setTextSize(TypedValue.COMPLEX_UNIT_PX, keyTextSize)
         keyRemove.setTextSize(TypedValue.COMPLEX_UNIT_PX, 0.8F * keyTextSize)
+        keySpecial.setTextSize(TypedValue.COMPLEX_UNIT_PX, keyTextSize)
 
         key1.setOnClickListener(listener)
         key2.setOnClickListener(listener)
@@ -164,6 +189,7 @@ class NumericKeyboard: FrameLayout {
         key8.setOnClickListener(listener)
         key9.setOnClickListener(listener)
         key0.setOnClickListener(listener)
+        keySpecial.setOnClickListener(listener)
 
         keyRemove.setOnClickListener(listener)
         keyRemove.setOnTouchListener { view, event ->
@@ -173,6 +199,16 @@ class NumericKeyboard: FrameLayout {
             }
 
             false
+        }
+
+        keySpecial.text = keySpecialText
+        if (keySpecialText != "") {
+            keySpecial.isEnabled = true
+        }
+        if (keySpecialListener != null) {
+            keySpecial.setOnClickListener(keySpecialListener)
+        } else {
+            keySpecial.setOnClickListener(listener)
         }
     }
 }

--- a/numeric-keyboard/src/main/java/com/konaire/numerickeyboard/NumericKeyboard.kt
+++ b/numeric-keyboard/src/main/java/com/konaire/numerickeyboard/NumericKeyboard.kt
@@ -189,7 +189,6 @@ class NumericKeyboard: FrameLayout {
         key8.setOnClickListener(listener)
         key9.setOnClickListener(listener)
         key0.setOnClickListener(listener)
-        keySpecial.setOnClickListener(listener)
 
         keyRemove.setOnClickListener(listener)
         keyRemove.setOnTouchListener { view, event ->

--- a/numeric-keyboard/src/main/res/layout/widget_keyboard.xml
+++ b/numeric-keyboard/src/main/res/layout/widget_keyboard.xml
@@ -133,10 +133,17 @@
         android:layout_height="@dimen/keyboard_row_height"
         android:orientation="horizontal">
 
-        <View
+        <TextView
+            android:id="@+id/keySpecial"
             android:layout_weight="1"
             android:layout_width="0px"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:text=""
+            android:enabled="false"
+            android:textColor="@android:color/black"
+            android:textSize="@dimen/keyboard_text_size"
+            android:background="?android:attr/selectableItemBackground" />
 
         <TextView
             android:id="@+id/key0"


### PR DESCRIPTION
CHANGES:
 * Added ```keySpecialText``` method to add custom text to special button;
Example:
    ``` kotlin
    // This will add a decimal separator
    keyboard.keySpecialText = "."
   ```
* Added ```onKeySpecialClick``` method to customize special button behaviour 
```kotlin
            // Example code to customize special button behaviour
            keyboard.keySpecialText = "TOAST"
            keyboard.onKeySpecialClick {
                Toast.makeText(this, "Special key pressed!", Toast.LENGTH_SHORT).show()
            }
```
Note that the second method is mandatory. If not specified, special text will just use the default listener and print its text in the EditText like the other buttons.

Please review.
